### PR TITLE
fix: 自分のmenu一覧の日本語対応、削除後の遷移先修正

### DIFF
--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -40,7 +40,8 @@ class MenusController < ApplicationController
 
   def destroy
     @menu.destroy!
-    redirect_to menus_path, success: t('defaults.message.deleted', item: Menu.model_name.human), status: :see_other
+    redirect_back_or_to(fallback_location: menus_path, status: :see_other)
+    flash['success'] = t('defaults.message.deleted', item: Menu.model_name.human)
   end
 
   def likes

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -58,6 +58,7 @@ ja:
       no_result: 'お気に入りのメニューがありません。'
     mymenus:
       title: '自分のメニュー一覧'
+      no_result: 'メニューがありません。'
   likes:
     create:
       success: 'お気に入りしました'


### PR DESCRIPTION
自分のmenu一覧について
・メニューがない時のメッセージを日本語対応に修正
・投稿削除後、自分のメニュー一覧に遷移するように変更