### PR TITLE
メニュー投稿時、必須データを見えるように変更

### DIFF
--- a/app/views/menus/_form.html.erb
+++ b/app/views/menus/_form.html.erb
@@ -2,7 +2,7 @@
   <%= render 'shared/error_messages', object: f.object %>
   <div class="form-group mb-3">
     <%= f.label :name %>
-    <%= f.text_field :name, class: 'form-control' %>
+    <%= f.text_field :name, class: 'form-control',placeholder: "必須" %>
   </div>
   <div class="form-group mb-3">
     <%= f.label :eat_at %>
@@ -10,7 +10,7 @@
   </div>
   <div class="form-group mb-3">
     <%= f.label :memo %>
-    <%= f.text_area :memo, class: 'form-control', rows: 10, placeholder: "おすすめ商品や店名、どんな気分の時などご自由に！" %>
+    <%= f.text_area :memo, class: 'form-control', rows: 10, placeholder: "おすすめ商品や店名、どんな気分の時などご自由に！(任意)" %>
   </div>
   <div class="form-group mb-3">
     <%= f.label :tag_name %>


### PR DESCRIPTION
メニューの投稿画面を以下変更
- メニュー名に必須のplaceholderを入れる
- メニューメモに任意のplaceholderを入れる
![スクリーンショット 2023-04-20 16 51 30](https://user-images.githubusercontent.com/102893104/233298369-7bd3f5a4-1447-4325-ae9f-ef395e1a531b.png)
