### PR TITLE
メニュー一覧の画像サイズの変更

### DIFF
--- a/app/views/menus/_form.html.erb
+++ b/app/views/menus/_form.html.erb
@@ -25,7 +25,7 @@
     <%= image_tag menu.menu_image.url,
                   class: 'border mb-3',
                   id: 'preview',
-                  size: '300x200' %>
+                  size: '300x300' %>
   </div>
   <%= f.submit class: 'btn btn-danger w-100' %>
 <% end %>

--- a/app/views/menus/_form.html.erb
+++ b/app/views/menus/_form.html.erb
@@ -2,7 +2,7 @@
   <%= render 'shared/error_messages', object: f.object %>
   <div class="form-group mb-3">
     <%= f.label :name %>
-    <%= f.text_field :name, class: 'form-control' %>
+    <%= f.text_field :name, class: 'form-control',placeholder: "必須" %>
   </div>
   <div class="form-group mb-3">
     <%= f.label :eat_at %>
@@ -10,7 +10,7 @@
   </div>
   <div class="form-group mb-3">
     <%= f.label :memo %>
-    <%= f.text_area :memo, class: 'form-control', rows: 10, placeholder: "おすすめ商品や店名、どんな気分の時などご自由に！" %>
+    <%= f.text_area :memo, class: 'form-control', rows: 10, placeholder: "おすすめ商品や店名、どんな気分の時などご自由に！(任意)" %>
   </div>
   <div class="form-group mb-3">
     <%= f.label :tag_name %>

--- a/app/views/menus/_menu.html.erb
+++ b/app/views/menus/_menu.html.erb
@@ -2,7 +2,7 @@
   <div id="menu-id-<%= menu.id %>">
     <div class="card mx-auto bg-light mb-3">
       <%= link_to menu_path(menu), class: "card-body text-dark link-color-black" do %>
-        <%= image_tag menu.menu_image_url, class: 'card-img-top border-bottom', size: '300x200' %>
+        <%= image_tag menu.menu_image_url, class: 'card-img-top border-bottom', size: '300x300' %>
         <h4 class="card-title mt-2">
           <%= menu.name %>
         </h4>

--- a/app/views/menus/show.html.erb
+++ b/app/views/menus/show.html.erb
@@ -21,7 +21,7 @@
             <%= simple_format(@menu.memo) %>
           </div>
           <div class='col-md-8 mb-2'>
-            <%= image_tag @menu.menu_image.url, class: 'card-img-top img-fluid border' %>
+            <%= image_tag @menu.menu_image.url, class: 'card-img-top img-fluid border', size: '300x300' %>
           </div>
           <div>
             <ul class="list-inline">


### PR DESCRIPTION
投稿写真の中心を切り取り、かつ縮尺も調整
<img width="649" alt="スクリーンショット 2023-04-20 22 46 41" src="https://user-images.githubusercontent.com/102893104/233388284-4e0ac9ac-ab01-4473-b89f-42d67cc9ab0e.png">
<img width="1403" alt="スクリーンショット 2023-04-20 22 47 14" src="https://user-images.githubusercontent.com/102893104/233388334-10da0086-cf71-4b3b-82e0-b18b9dc78d1a.png">
<img width="827" alt="スクリーンショット 2023-04-20 22 47 29" src="https://user-images.githubusercontent.com/102893104/233388408-bb463857-50c9-4bc1-9423-4fd6ef7a0bae.png">
